### PR TITLE
[#8] add config package for const variable of DEBUG (bool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ GOMObile SIMple wRApper
 * everything is under construction.
 * see `example` directory to know how to use.
 
+# Build
+
+* For Release build, `go build -tags=release` or `gomobile build -tags=release`
+  * This efforts that logging for debug is disabled.
+
 # License
 
 MIT

--- a/config/env_debug.go
+++ b/config/env_debug.go
@@ -1,0 +1,5 @@
+// +build !release
+
+package config
+
+const DEBUG = true

--- a/config/env_release.go
+++ b/config/env_release.go
@@ -1,0 +1,5 @@
+// +build release
+
+package config
+
+const DEBUG = false

--- a/peer/log.go
+++ b/peer/log.go
@@ -3,6 +3,8 @@ package peer
 import (
 	"fmt"
 	"runtime"
+
+	"github.com/pankona/gomo-simra/config"
 )
 
 func printLog(tag string, format string, a ...interface{}) {
@@ -20,7 +22,9 @@ func printLog(tag string, format string, a ...interface{}) {
 }
 
 func LogDebug(format string, a ...interface{}) {
-	printLog("DEBUG", format, a...)
+	if config.DEBUG {
+		printLog("DEBUG", format, a...)
+	}
 
 }
 


### PR DESCRIPTION
## PR for #8 

## Updates
* add package for const variable DEBUG
* `LogDebug` is now available only when `DEBUG = false`
* use `go build -tags=release` for release build.