### PR TITLE
update ci for docker to use circleci/golang1.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/golang:1.10.3
+FROM circleci/golang:1.11.1
 
 ENV HOME     /home/circleci
 WORKDIR      $HOME


### PR DESCRIPTION
## Updates

- use circleci/golang1.11.1 docker image for ci
