### PR TITLE
don't call dec.Close() since the function has been removed

### DIFF
--- a/simra/audio.go
+++ b/simra/audio.go
@@ -42,10 +42,6 @@ func (a *audio) Play(resource asset.File, loop bool, doneCallback func(err error
 		if err != nil && err != io.EOF {
 			simlog.Error(err)
 		}
-		err = dec.Close()
-		if err != nil {
-			simlog.Error(err)
-		}
 		err = player.Close()
 		if err != nil {
 			simlog.Error(err)


### PR DESCRIPTION
## Updates
* Don't call mp3.Decoder.Close() function since it has been removed.
